### PR TITLE
failing test case

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "url": "https://github.com/lucasefe/eslint-plugin-sort-align-assignments"
   },
   "scripts": {
-    "test": "mocha tests/lib/rules/align-assignments_test.js"
+    "test": "mocha tests/lib/rules/align-assignments_test.js",
+    "watch": "mocha -w tests/lib/rules/align-assignments_test.js --reporter=dot"
   },
   "devDependencies": {
     "eslint": "^5.9.0",

--- a/tests/lib/rules/align-assignments_test.js
+++ b/tests/lib/rules/align-assignments_test.js
@@ -26,7 +26,7 @@ ruleTester.run('align-assignments', rule, {
     {
       code: code([
         'const ABC = require()',
-        'const A   = require()'
+        'const A   = prequire()'
       ])
     },
     {
@@ -163,6 +163,21 @@ ruleTester.run('align-assignments', rule, {
         "const a = require('a')",
         "const bbb   = require('abc')",
         "const cc         = require('abc')"
+      ]),
+      output: code([
+        "const a   = require('a')",
+        "const bbb = require('abc')",
+        "const cc  = require('abc')"
+      ]),
+      errors: [
+        { message: 'This group of assignments is not aligned' }
+      ]
+    },
+    {
+      code: code([
+        "const a   =  require('a')",
+        "const bbb = require('abc')",
+        "const cc  = require('abc')"
       ]),
       output: code([
         "const a   = require('a')",


### PR DESCRIPTION
hey @lucasefe --

I was tinkering with https://github.com/arcanis/eslint-plugin-arca yesterday and learned a bit about deving eslint plugins. I noticed an issue with extra spaces in align assignments, so I added a failing test case in this branch:

```
    {
      code: code([
        "const a   =  require('a')",
        "const bbb = require('abc')",
        "const cc  = require('abc')"
      ]),
      output: code([
        "const a   = require('a')",
        "const bbb = require('abc')",
        "const cc  = require('abc')"
      ]),
      errors: [
        { message: 'This group of assignments is not aligned' }
      ]
    },
```
(Note the extra space after the = in the first line.)

Should this plugin remove that extra space, or do you think that task is better left to some other plugin?