### PR TITLE
Support all assignment operators

### DIFF
--- a/lib/rules/align-assignments.js
+++ b/lib/rules/align-assignments.js
@@ -9,7 +9,7 @@
 // ------------------------------------------------------------------------------
 
 const hasRequire   = /require\(/;
-const spaceMatcher = /(\s*)=/;
+const spaceMatcher = /(\s*)((?:\+|-|\*|\/|%|&|\^|\||<<|>>|\*\*|>>>)?=)/;
 
 module.exports = {
   meta: {
@@ -121,7 +121,7 @@ module.exports = {
       const prefix   = getPrefix(node);
       const source   = sourceCode.getText(node);
       const match    = source.substr(prefix).match(spaceMatcher);
-      const position = match ? match.index + prefix + 1 : null;
+      const position = match ? match.index + prefix + match[2].length : null;
       return position;
     }
 

--- a/lib/rules/align-assignments.js
+++ b/lib/rules/align-assignments.js
@@ -88,7 +88,7 @@ module.exports = {
             const fixings = group.map(function(node) {
               const tokens           = sourceCode.getTokens(node);
               const firstToken       = tokens[0];
-              const assignmentToken  = tokens.find(token => token.value === '=');
+              const assignmentToken  = tokens.find(token => ['=', '+=', '-=', '*=', '/=', '%=', '&=', '^=', '|=', '<<=', '>>=', '**=', '>>>='].includes(token.value));
               const line             = sourceCode.getText(node);
               const lineIsAligned    = line.charAt(maxPos) === '=';
               if (lineIsAligned || !assignmentToken || isMultiline(firstToken, assignmentToken))
@@ -100,9 +100,9 @@ module.exports = {
                 const endDelimiter   = assignmentToken.loc.end.column - spacePrefix;
                 const start          = line.slice(0, startDelimiter).replace(/\s+$/m, '');
                 const ending         = line.slice(endDelimiter).replace(/^\s+/m, '');
-                const spacesRequired = maxPos - start.length;
+                const spacesRequired = maxPos - start.length - assignmentToken.value.length + 1;
                 const spaces         = ' '.repeat(spacesRequired);
-                const fixedText      = `${start}${spaces}= ${ending}`;
+                const fixedText      = `${start}${spaces}${assignmentToken.value} ${ending}`;
                 return fixer.replaceText(node, fixedText);
               }
             });

--- a/tests/lib/rules/align-assignments_test.js
+++ b/tests/lib/rules/align-assignments_test.js
@@ -419,10 +419,10 @@ ruleTester.run('align-assignments', rule, {
         'let A = 0',
         'A += 1'
       ]),
-      // output:    code([
-      //   'let A = 1',
-      //   'A    += 1'
-      // ]),
+      output:    code([
+        'let A = 0',
+        'A    += 1'
+      ]),
       errors: [{ message: 'This group of assignments is not aligned' }]
     },
     {
@@ -465,12 +465,45 @@ ruleTester.run('align-assignments', rule, {
         'C = 1',
         'D <<= 1'
       ]),
-      // output: code([
-      //   'A   -= 1',
-      //   'B >>>= 1',
-      //   'C    = 1',
-      //   'D  <<= 1'
-      // ]),
+      output: code([
+        'A   -= 1',
+        'B >>>= 1',
+        'C    = 1',
+        'D  <<= 1'
+      ]),
+      errors: [{ message: 'This group of assignments is not aligned' }]
+    },
+    {
+      code:    code([
+        'A >>>= 1',
+        'B **= 1',
+        'C >>= 1',
+        'D <<= 1',
+        'E |= 1',
+        'F ^= 1',
+        'G &= 1',
+        'H %= 1',
+        'I /= 1',
+        'J *= 1',
+        'K -= 1',
+        'L += 1',
+        'M = 1'
+      ]),
+      output: code([
+        'A >>>= 1',
+        'B  **= 1',
+        'C  >>= 1',
+        'D  <<= 1',
+        'E   |= 1',
+        'F   ^= 1',
+        'G   &= 1',
+        'H   %= 1',
+        'I   /= 1',
+        'J   *= 1',
+        'K   -= 1',
+        'L   += 1',
+        'M    = 1'
+      ]),
       errors: [{ message: 'This group of assignments is not aligned' }]
     }
   ]

--- a/tests/lib/rules/align-assignments_test.js
+++ b/tests/lib/rules/align-assignments_test.js
@@ -361,6 +361,121 @@ ruleTester.run('align-assignments', rule, {
   ]
 });
 
+ruleTester.run('align-assignments', rule, {
+  valid: [
+    {
+      code:    code([
+        'let A = 1',
+        'A    += 1'
+      ])
+    },
+    {
+      code:    code([
+        'A  = 1',
+        'B += 1'
+      ])
+    },
+    {
+      code:    code([
+        'A   = 1',
+        'B >>= 1'
+      ])
+    },
+    {
+      code:    code([
+        'A    = 1',
+        'B >>>= 1'
+      ])
+    },
+    {
+      code:    code([
+        'A   -= 1',
+        'B >>>= 1',
+        'C    = 1',
+        'D  <<= 1'
+      ])
+    },
+    {
+      code:    code([
+        'A >>>= 1',
+        'B  **= 1',
+        'C  >>= 1',
+        'D  <<= 1',
+        'E   |= 1',
+        'F   ^= 1',
+        'G   &= 1',
+        'H   %= 1',
+        'I   /= 1',
+        'J   *= 1',
+        'K   -= 1',
+        'L   += 1',
+        'M    = 1'
+      ])
+    }
+  ],
+  invalid: [
+    {
+      code:    code([
+        'let A = 0',
+        'A += 1'
+      ]),
+      // output:    code([
+      //   'let A = 1',
+      //   'A    += 1'
+      // ]),
+      errors: [{ message: 'This group of assignments is not aligned' }]
+    },
+    {
+      code:    code([
+        'A = 1',
+        'B += 1'
+      ]),
+      output: code([
+        'A  = 1',
+        'B += 1'
+      ]),
+      errors: [{ message: 'This group of assignments is not aligned' }]
+    },
+    {
+      code:    code([
+        'A = 1',
+        'B >>= 1'
+      ]),
+      output: code([
+        'A   = 1',
+        'B >>= 1'
+      ]),
+      errors: [{ message: 'This group of assignments is not aligned' }]
+    },
+    {
+      code:    code([
+        'A = 1',
+        'B >>>= 1'
+      ]),
+      output: code([
+        'A    = 1',
+        'B >>>= 1'
+      ]),
+      errors: [{ message: 'This group of assignments is not aligned' }]
+    },
+    {
+      code:    code([
+        'A -= 1',
+        'B >>>= 1',
+        'C = 1',
+        'D <<= 1'
+      ]),
+      // output: code([
+      //   'A   -= 1',
+      //   'B >>>= 1',
+      //   'C    = 1',
+      //   'D  <<= 1'
+      // ]),
+      errors: [{ message: 'This group of assignments is not aligned' }]
+    }
+  ]
+});
+
 
 function code(lines) {
   return lines.join('\n');


### PR DESCRIPTION
I added ~~basic~~ support for the other assignment operators as described in #2

The lint rule should be working for all operators, ~~however lint fixing is only partially supported at the moment. It will work as long as the position of the single '=' operator needs to be changes, where as if the position of an alternative operator needs to be changed it will not make any changes to this line.~~

~~I have not found any way to fix this behavior yet, however I think that even without the fix support this would already be good addition :) .~~

I managed to add support for lint fixing as well! :D